### PR TITLE
Param validator [prep work]

### DIFF
--- a/server/src/routes/middlewares/paramValidator.js
+++ b/server/src/routes/middlewares/paramValidator.js
@@ -1,3 +1,2 @@
-module.exports = (req, res, next) => (
-  word.length > 0 ? res.send(400) : next()
-)
+module.exports = ({ params }, res, next) =>
+  params.word.length > 0 ? next() : res.sendStatus(400)

--- a/server/src/routes/middlewares/paramValidator.js
+++ b/server/src/routes/middlewares/paramValidator.js
@@ -1,0 +1,3 @@
+module.exports = (req, res, next) => (
+  word.length > 0 ? res.send(400) : next()
+)

--- a/server/src/routes/routing.js
+++ b/server/src/routes/routing.js
@@ -3,9 +3,10 @@
 const router = require('express').Router()
 const Request = require('../lib/Request.js')
 const Builder = require('../lib/Builder.js')
+const paramValidator = require('./middlewares/paramValidator')
 
 router.route('/translate/:word')
-.get((req, res) => {
+.get(paramValidator, (req, res) => {
 
     /**
      * TODO: Make sure empty words cant pass through


### PR DESCRIPTION
Server-side rejects empty translation requests and sends a 400.